### PR TITLE
Fix todo-comments plugin duplication

### DIFF
--- a/lua/plugins/misc.lua
+++ b/lua/plugins/misc.lua
@@ -28,13 +28,6 @@ return {
     opts = {},
   },
   {
-    -- Highlight todo, notes, etc in comments
-    'folke/todo-comments.nvim',
-    event = 'VimEnter',
-    dependencies = { 'nvim-lua/plenary.nvim' },
-    opts = { signs = false },
-  },
-  {
     -- High-performance color highlighter
     'norcalli/nvim-colorizer.lua',
     config = function()

--- a/lua/plugins/todo-comments.lua
+++ b/lua/plugins/todo-comments.lua
@@ -1,9 +1,6 @@
 return {
   'folke/todo-comments.nvim',
+  event = 'VimEnter',
   dependencies = { 'nvim-lua/plenary.nvim' },
-  opts = {
-    -- your configuration comes here
-    -- or leave it empty to use the default settings
-    -- refer to the configuration section below
-  },
+  opts = { signs = false },
 }


### PR DESCRIPTION
## Summary
- remove duplicate `todo-comments.nvim` block from `misc.lua`
- set up `todo-comments.nvim` plugin with `VimEnter` event and options

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840cc63dac48324ab6eb0f08ce0b7b9